### PR TITLE
[날씨 데이터 관리] feat: KAN-63 기상청 배치 수집

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,9 @@ dependencies {
     annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
     annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 
+    // Batch
+    implementation 'org.springframework.boot:spring-boot-starter-batch'
+
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.testcontainers:junit-jupiter'

--- a/src/main/java/com/team1/otvoo/config/RestTemplateConfig.java
+++ b/src/main/java/com/team1/otvoo/config/RestTemplateConfig.java
@@ -1,0 +1,14 @@
+package com.team1.otvoo.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+  @Bean
+  public RestTemplate restTemplate() {
+    return new RestTemplate();
+  }
+}

--- a/src/main/java/com/team1/otvoo/exception/ErrorCode.java
+++ b/src/main/java/com/team1/otvoo/exception/ErrorCode.java
@@ -52,6 +52,8 @@ public enum ErrorCode implements Code{
   UNKNOWN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "예기치 못한 오류가 발생했습니다."),
   IO_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "입출력 처리 중 오류가 발생했습니다."),
   DATABASE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "데이터베이스 처리 중 오류가 발생했습니다."),
+  EXTERNAL_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "외부 API 호출 중 오류가 발생했습니다."),
+  EXTERNAL_API_EMPTY_RESPONSE(HttpStatus.INTERNAL_SERVER_ERROR, "외부 API가 빈 응답을 반환했습니다."),
 
   // --- Clothes 관련 ErrorCode ---
   ATTRIBUTE_DEFINITION_DUPLICATE(HttpStatus.CONFLICT, "이미 존재하는 의상 속성 정의입니다."),

--- a/src/main/java/com/team1/otvoo/weather/batch/WeatherForecastProcessor.java
+++ b/src/main/java/com/team1/otvoo/weather/batch/WeatherForecastProcessor.java
@@ -1,0 +1,160 @@
+package com.team1.otvoo.weather.batch;
+
+
+import com.team1.otvoo.weather.dto.VilageFcstResponse.FcstItem;
+import com.team1.otvoo.weather.entity.PrecipitationType;
+import com.team1.otvoo.weather.entity.SkyStatus;
+import com.team1.otvoo.weather.entity.WeatherForecast;
+import com.team1.otvoo.weather.entity.WeatherHumidity;
+import com.team1.otvoo.weather.entity.WeatherLocation;
+import com.team1.otvoo.weather.entity.WeatherPrecipitation;
+import com.team1.otvoo.weather.entity.WeatherTemperature;
+import com.team1.otvoo.weather.entity.WeatherWindSpeed;
+import com.team1.otvoo.weather.entity.WindStrength;
+import com.team1.otvoo.weather.util.FcstItemUtils;
+import com.team1.otvoo.weather.util.ForecastParsingUtils;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+
+/**
+ * 날씨 API에서 받아온 원시 데이터(List<FcstItem>)를
+ * 도메인의 WeatherForecast 엔티티(및 연관된 서브 엔티티)로 변환하는 책임
+ */
+@Slf4j
+@Component
+@StepScope
+@RequiredArgsConstructor
+public class WeatherForecastProcessor implements
+    ItemProcessor<List<FcstItem>, List<WeatherForecast>> {
+
+  private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd");
+  private static final DateTimeFormatter TIME_FORMAT = DateTimeFormatter.ofPattern("HHmm");
+  private static final ZoneId ZONE = ZoneId.of("Asia/Seoul");
+
+  @Value("#{jobParameters['latitude']}")
+  private double latitude;
+
+  @Value("#{jobParameters['longitude']}")
+  private double longitude;
+
+  @Value("#{jobParameters['x']}")
+  private int x;
+
+  @Value("#{jobParameters['y']}")
+  private int y;
+
+  @Value("#{jobParameters['locationNames']}")
+  private String locationNames;
+
+  private final ForecastParsingUtils parsingUtils;
+
+  @Override
+  public List<WeatherForecast> process(List<FcstItem> items) {
+    log.debug("Processor 입력 데이터 개수: {}", items.size());
+
+    // 1. fcstDate + fcstTime 기준으로 그룹핑
+    Map<ForecastKey, List<FcstItem>> grouped = items.stream()
+        .collect(Collectors.groupingBy(
+            item -> new ForecastKey(item.getFcstDate(), item.getFcstTime())
+        ));
+
+    List<WeatherForecast> results = new ArrayList<>();
+
+    // 2. FcstItemUtils로 카테고리별 값 파싱
+    for (Map.Entry<ForecastKey, List<FcstItem>> entry : grouped.entrySet()) {
+      ForecastKey key = entry.getKey();
+      List<FcstItem> group = entry.getValue();
+
+      // - 온도 -
+      Double tmp = FcstItemUtils.parseDoubleByCategory(group, "TMP", parsingUtils);
+      Double tmn = FcstItemUtils.parseDoubleByCategory(group, "TMN", parsingUtils);
+      Double tmx = FcstItemUtils.parseDoubleByCategory(group, "TMX", parsingUtils);
+
+      // - 습도 -
+      Double reh = FcstItemUtils.parseDoubleByCategory(group, "REH", parsingUtils);
+
+      // - 풍속 -
+      Double wsd = FcstItemUtils.parseDoubleByCategory(group, "WSD", parsingUtils);
+      WindStrength windStrength = (wsd != null)
+          ? WindStrength.fromSpeed(wsd)
+          : WindStrength.WEAK;
+
+      // - 강수 확률 -
+      Double pop = FcstItemUtils.parseDoubleByCategory(group, "POP", parsingUtils);
+
+      // - 강수 형태 & 양 -
+      int ptyCode = FcstItemUtils.parseIntByCategory(group, "PTY", parsingUtils);
+      PrecipitationType precipitationType = PrecipitationType.fromCode(ptyCode);
+      Double pcp = FcstItemUtils.parsePrecipOrSnowByCategory(group, "PCP", parsingUtils);
+
+      // — 하늘 상태 —
+      int skyCode = FcstItemUtils.parseIntByCategory(group, "SKY", parsingUtils);
+      SkyStatus skyStatus = SkyStatus.fromCode(skyCode);
+
+      // 예보 시각 계산 (forecastedAt -> 예보 발표알, forecastAt -> 예보 적용일)
+      FcstItem first = group.get(0);
+      Instant forecastedAt = LocalDateTime.of(
+          LocalDate.parse(first.getBaseDate(), DATE_FORMAT),
+          LocalTime.parse(first.getBaseTime(), TIME_FORMAT)
+      ).atZone(ZONE).toInstant();
+      Instant forecastAt = LocalDateTime.of(
+          LocalDate.parse(key.fcstDate(), DATE_FORMAT),
+          LocalTime.parse(key.fcstTime(), TIME_FORMAT)
+      ).atZone(ZONE).toInstant();
+
+      // 엔티티 생성 및 연동
+      WeatherForecast forecast = WeatherForecast.of(forecastedAt, forecastAt, skyStatus);
+      List<String> regions = Arrays.asList(locationNames.split(","));
+      WeatherLocation location = new WeatherLocation(
+          forecast,
+          x, y,
+          latitude, longitude,
+          regions
+      );
+      forecast.setLocation(location);
+
+      // comparedToDayBefore -> 추후 계산 로직 반영 예정
+      WeatherTemperature temperature = new WeatherTemperature(forecast, tmp, tmn, tmx, 0.0);
+      forecast.setTemperature(temperature);
+
+      // comparedToDayBefore -> 추후 계산 로직 반영 예정
+      WeatherHumidity humidity = new WeatherHumidity(forecast, reh, 0.0);
+      forecast.setHumidity(humidity);
+
+      WeatherPrecipitation precipitation = new WeatherPrecipitation(forecast, precipitationType, pcp, pop);
+      forecast.setPrecipitation(precipitation);
+
+      WeatherWindSpeed windSpeed = new WeatherWindSpeed(forecast, wsd, windStrength);
+      forecast.setWindSpeed(windSpeed);
+
+      results.add(forecast);
+    }
+
+    return results;
+  }
+
+  // 날짜 + 시간 조합 Key
+  public record ForecastKey(String fcstDate, String fcstTime) {
+
+    public String asString() {
+      return fcstDate + fcstTime;
+    }
+  }
+
+}

--- a/src/main/java/com/team1/otvoo/weather/client/KakaoLocalClient.java
+++ b/src/main/java/com/team1/otvoo/weather/client/KakaoLocalClient.java
@@ -1,0 +1,77 @@
+package com.team1.otvoo.weather.client;
+
+import com.team1.otvoo.exception.ErrorCode;
+import com.team1.otvoo.exception.RestException;
+import com.team1.otvoo.weather.dto.KakaoRegionResponse;
+import java.net.URI;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KakaoLocalClient {
+
+  private final RestTemplate restTemplate;
+
+  @Value("${kakao.local.api.base-url}")
+  private String kakaoBaseUrl;
+
+  @Value("${kakao.local.api.service-key}")
+  private String kakaoApiKey;
+
+  public List<String> getRegionNames(double latitude, double longitude) {
+    // 1. API 요청 URL 생성
+    URI uri = UriComponentsBuilder.fromUriString(kakaoBaseUrl)
+        .queryParam("x", longitude)
+        .queryParam("y", latitude)
+        .build()
+        .toUri();
+
+    // 2. 요청 헤더 구성 (Authorization)
+    HttpHeaders headers = new HttpHeaders();
+    headers.set("Authorization", "KakaoAK " + kakaoApiKey);
+
+    // 3. HttpEntity 생성 (헤더만 담음)
+    HttpEntity<Void> entity = new HttpEntity<>(headers);
+
+    // 4. 카카오 API 요청 실행
+    ResponseEntity<KakaoRegionResponse> response;
+    try {
+      response = restTemplate.exchange(
+          uri,
+          HttpMethod.GET,
+          entity,
+          KakaoRegionResponse.class // 응답을 KakaoRegionResponse로 파싱
+      );
+    } catch (Exception e) {
+      log.error("카카오 위치 API 호출 실패", e);
+      throw new RestException(ErrorCode.EXTERNAL_API_ERROR);
+    }
+
+    if (response.getStatusCode() != HttpStatus.OK || response.getBody() == null) {
+      log.warn("카카오 API 응답 실패: status={}, body={}", response.getStatusCode(), response.getBody());
+      throw new RestException(ErrorCode.EXTERNAL_API_ERROR);
+    }
+
+    // 5. 응답의 documents 배열에서 첫 번째 결과만 추출
+    KakaoRegionResponse.Document doc = response.getBody()
+        .documents()
+        .stream()
+        .findFirst()
+        .orElseThrow(() -> new RestException(ErrorCode.EXTERNAL_API_EMPTY_RESPONSE));
+
+    return List.of(doc.region1(), doc.region2(), doc.region3());
+  }
+
+}

--- a/src/main/java/com/team1/otvoo/weather/client/WeatherClient.java
+++ b/src/main/java/com/team1/otvoo/weather/client/WeatherClient.java
@@ -1,0 +1,46 @@
+package com.team1.otvoo.weather.client;
+
+import com.team1.otvoo.weather.client.dto.VilageFcstResponse;
+
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WeatherClient {
+
+  private final RestTemplate restTemplate;
+
+  @Value("${weather.api.base-url}")
+  private String baseUrl;
+
+  @Value("${weather.api.service-key}")
+  private String serviceKey;
+
+  public VilageFcstResponse getForecast(String baseDate, String baseTime, int nx, int ny, int numOfRows) {
+    URI uri = UriComponentsBuilder.fromUriString(baseUrl)
+        .queryParam("serviceKey", serviceKey)
+        .queryParam("numOfRows", numOfRows)
+        .queryParam("pageNo", 1)
+        .queryParam("dataType", "JSON")
+        .queryParam("base_date", baseDate)
+        .queryParam("base_time", baseTime)
+        .queryParam("nx", nx)
+        .queryParam("ny", ny)
+        .build(true) // 인코딩된 serviceKey 가 있다면, 다시 인코딩 하지 않게 설정
+        .toUri();
+
+    log.debug("기상청 예보 API 호출: {}", uri);
+
+    // 1. 위에서 만든 uri로, HTTP GET 요청을 날리고
+    // 2. 응답 바디(JSON)을 DTO 클래스로 변환해서 리턴받음
+    return restTemplate.getForObject(uri, VilageFcstResponse.class);
+  }
+
+}

--- a/src/main/java/com/team1/otvoo/weather/client/WeatherClient.java
+++ b/src/main/java/com/team1/otvoo/weather/client/WeatherClient.java
@@ -1,6 +1,6 @@
 package com.team1.otvoo.weather.client;
 
-import com.team1.otvoo.weather.client.dto.VilageFcstResponse;
+import com.team1.otvoo.weather.dto.VilageFcstResponse;
 
 import java.net.URI;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/team1/otvoo/weather/client/dto/VilageFcstResponse.java
+++ b/src/main/java/com/team1/otvoo/weather/client/dto/VilageFcstResponse.java
@@ -1,0 +1,39 @@
+package com.team1.otvoo.weather.client.dto;
+
+import java.util.List;
+import lombok.Data;
+
+@Data
+public class VilageFcstResponse {
+
+  private ResponseHeader header;
+  private ResponseBody body;
+
+  @Data
+  public static class ResponseHeader {
+    private String resultCode;
+    private String resultMsg;
+  }
+
+  @Data
+  public static class ResponseBody {
+    private Items items;
+  }
+
+  @Data
+  public static class Items {
+    private List<FcstItem> item;
+  }
+
+  @Data
+  public static class FcstItem {
+    private String baseDate;
+    private String baseTime;
+    private String category;
+    private String fcstDate;
+    private String fcstTime;
+    private String fcstValue;
+    private int nx;
+    private int ny;
+  }
+}

--- a/src/main/java/com/team1/otvoo/weather/dto/KakaoRegionResponse.java
+++ b/src/main/java/com/team1/otvoo/weather/dto/KakaoRegionResponse.java
@@ -1,0 +1,18 @@
+package com.team1.otvoo.weather.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+public record KakaoRegionResponse(
+    @JsonProperty("documents")
+    List<Document> documents
+) {
+  public record Document(
+      @JsonProperty("region_1depth_name")
+      String region1,
+      @JsonProperty("region_2depth_name")
+      String region2,
+      @JsonProperty("region_3depth_name")
+      String region3
+  ) {}
+}

--- a/src/main/java/com/team1/otvoo/weather/dto/VilageFcstResponse.java
+++ b/src/main/java/com/team1/otvoo/weather/dto/VilageFcstResponse.java
@@ -3,6 +3,7 @@ package com.team1.otvoo.weather.dto;
 import java.util.List;
 import lombok.Data;
 
+// 기상청 단기예보 조회 API(getVilageFcst) 응답 DTO
 @Data
 public class VilageFcstResponse {
 
@@ -35,5 +36,19 @@ public class VilageFcstResponse {
     private String fcstValue;
     private int nx;
     private int ny;
+
+    public FcstItem(String baseDate, String baseTime,
+        String fcstDate, String fcstTime,
+        String category, String fcstValue,
+        int nx, int ny) {
+      this.baseDate  = baseDate;
+      this.baseTime  = baseTime;
+      this.fcstDate  = fcstDate;
+      this.fcstTime  = fcstTime;
+      this.category  = category;
+      this.fcstValue = fcstValue;
+      this.nx        = nx;
+      this.ny        = ny;
+    }
   }
 }

--- a/src/main/java/com/team1/otvoo/weather/dto/VilageFcstResponse.java
+++ b/src/main/java/com/team1/otvoo/weather/dto/VilageFcstResponse.java
@@ -1,4 +1,4 @@
-package com.team1.otvoo.weather.client.dto;
+package com.team1.otvoo.weather.dto;
 
 import java.util.List;
 import lombok.Data;

--- a/src/main/java/com/team1/otvoo/weather/entity/PrecipitationType.java
+++ b/src/main/java/com/team1/otvoo/weather/entity/PrecipitationType.java
@@ -6,5 +6,15 @@ public enum PrecipitationType {
   RAIN,       // 비 (1)
   RAIN_SNOW,  // 비/눈 (2)
   SNOW,       // 눈 (3)
-  SHOWER      // 소나기 (4)
+  SHOWER;     // 소나기 (4)
+
+  public static PrecipitationType fromCode(int code) {
+    return switch (code) {
+      case 1 -> RAIN;
+      case 2 -> RAIN_SNOW;
+      case 3 -> SNOW;
+      case 4 -> SHOWER;
+      default -> NONE;
+    };
+  }
 }

--- a/src/main/java/com/team1/otvoo/weather/entity/SkyStatus.java
+++ b/src/main/java/com/team1/otvoo/weather/entity/SkyStatus.java
@@ -4,5 +4,14 @@ package com.team1.otvoo.weather.entity;
 public enum SkyStatus {
   CLEAR,           // 맑음 (기상청 코드 1)
   MOSTLY_CLOUDY,   // 구름 많음 (기상청 코드 3)
-  CLOUDY           // 흐림 (기상청 코드 4)
+  CLOUDY;          // 흐림 (기상청 코드 4)
+
+  public static SkyStatus fromCode(int code) {
+    return switch (code) {
+      case 1 -> CLEAR;
+      case 3 -> MOSTLY_CLOUDY;
+      case 4 -> CLOUDY;
+      default -> CLEAR; // 기본값: 맑음
+    };
+  }
 }

--- a/src/main/java/com/team1/otvoo/weather/entity/WeatherForecast.java
+++ b/src/main/java/com/team1/otvoo/weather/entity/WeatherForecast.java
@@ -65,6 +65,10 @@ public class WeatherForecast {
     this.updatedAt = Instant.now();
   }
 
+  public static WeatherForecast of(Instant forecastedAt, Instant forecastAt, SkyStatus skyStatus) {
+    return new WeatherForecast(forecastedAt, forecastAt, skyStatus);
+  }
+
   public void updateSkyStatus(SkyStatus skyStatus) {
     this.skyStatus = skyStatus;
     this.updatedAt = Instant.now();

--- a/src/main/java/com/team1/otvoo/weather/entity/WeatherForecast.java
+++ b/src/main/java/com/team1/otvoo/weather/entity/WeatherForecast.java
@@ -12,13 +12,14 @@ import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.time.Instant;
 import java.util.UUID;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "weather_forecasts")
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class WeatherForecast {
 
   @Id

--- a/src/main/java/com/team1/otvoo/weather/entity/WeatherHumidity.java
+++ b/src/main/java/com/team1/otvoo/weather/entity/WeatherHumidity.java
@@ -8,13 +8,14 @@ import jakarta.persistence.MapsId;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.util.UUID;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "weather_humidities")
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class WeatherHumidity {
 
   @Id

--- a/src/main/java/com/team1/otvoo/weather/entity/WeatherLocation.java
+++ b/src/main/java/com/team1/otvoo/weather/entity/WeatherLocation.java
@@ -10,17 +10,14 @@ import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.util.List;
 import java.util.UUID;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "weather_locations")
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class WeatherLocation {
 
   @Id

--- a/src/main/java/com/team1/otvoo/weather/entity/WeatherPrecipitation.java
+++ b/src/main/java/com/team1/otvoo/weather/entity/WeatherPrecipitation.java
@@ -10,15 +10,14 @@ import jakarta.persistence.MapsId;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.util.UUID;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "weather_precipitations")
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class WeatherPrecipitation {
 
   @Id

--- a/src/main/java/com/team1/otvoo/weather/entity/WeatherTemperature.java
+++ b/src/main/java/com/team1/otvoo/weather/entity/WeatherTemperature.java
@@ -8,15 +8,14 @@ import jakarta.persistence.MapsId;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.util.UUID;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "weather_temperatures")
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class WeatherTemperature {
 
   @Id

--- a/src/main/java/com/team1/otvoo/weather/entity/WeatherWindSpeed.java
+++ b/src/main/java/com/team1/otvoo/weather/entity/WeatherWindSpeed.java
@@ -10,15 +10,14 @@ import jakarta.persistence.MapsId;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.util.UUID;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "weather_wind_speeds")
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class WeatherWindSpeed {
 
   @Id

--- a/src/main/java/com/team1/otvoo/weather/entity/WindStrength.java
+++ b/src/main/java/com/team1/otvoo/weather/entity/WindStrength.java
@@ -4,5 +4,11 @@ package com.team1.otvoo.weather.entity;
 public enum WindStrength {
   WEAK,
   MODERATE,
-  STRONG
+  STRONG;
+
+  public static WindStrength fromSpeed(double speed) {
+    if (speed < 4) return WEAK;
+    if (speed < 9) return MODERATE;
+    return STRONG;
+  }
 }

--- a/src/main/java/com/team1/otvoo/weather/mapper/WeatherMapper.java
+++ b/src/main/java/com/team1/otvoo/weather/mapper/WeatherMapper.java
@@ -1,13 +1,22 @@
 package com.team1.otvoo.weather.mapper;
 
 import com.team1.otvoo.user.dto.Location;
+import com.team1.otvoo.weather.dto.HumidityDto;
 import com.team1.otvoo.weather.dto.PrecipitationDto;
 import com.team1.otvoo.weather.dto.TemperatureDto;
+import com.team1.otvoo.weather.dto.WeatherAPILocation;
+import com.team1.otvoo.weather.dto.WeatherDto;
 import com.team1.otvoo.weather.dto.WeatherSummaryDto;
+import com.team1.otvoo.weather.dto.WindSpeedDto;
 import com.team1.otvoo.weather.entity.WeatherForecast;
+import com.team1.otvoo.weather.entity.WeatherHumidity;
+import com.team1.otvoo.weather.entity.WeatherLocation;
 import com.team1.otvoo.weather.entity.WeatherLocation;
 import com.team1.otvoo.weather.entity.WeatherPrecipitation;
 import com.team1.otvoo.weather.entity.WeatherTemperature;
+import com.team1.otvoo.weather.entity.WeatherWindSpeed;
+import java.util.Collections;
+import java.util.List;
 import java.util.Arrays;
 import java.util.List;
 import org.mapstruct.Mapper;
@@ -15,19 +24,32 @@ import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface WeatherMapper {
+
+  // Weather -> Summary DTO (피드용)
   @Mapping(source = "id", target = "weatherId")
-  @Mapping(source = "precipitation", target = "precipitation")
-  @Mapping(source = "temperature", target = "temperature")
-  WeatherSummaryDto toSummaryDto(WeatherForecast weatherForecast);
+  WeatherSummaryDto toSummaryDto(WeatherForecast forecast);
+
+  // Weather -> Full DTO(상세 API용)
+  WeatherDto toDto(WeatherForecast forecast);
+
+  // 단일 하위 엔티티 -> DTO 매핑
   PrecipitationDto toPrecipitationDto(WeatherPrecipitation entity);
   TemperatureDto toTemperatureDto(WeatherTemperature entity);
+  HumidityDto toHumidityDto(WeatherHumidity entity);
+  WindSpeedDto toWindSpeedDto(WeatherWindSpeed entity);
+
+  // List<WeatherForecast> -> List<WeatherSummaryDto>
+  List<WeatherSummaryDto> toSummaryList(List<WeatherForecast> forecasts);
+
+  @Mapping(target = "locationNames", expression = "java(splitLocationNames(entity.getLocationNames()))" )
+  WeatherAPILocation toWeatherAPILocation(WeatherLocation entity);
 
   @Mapping(target = "locationNames", expression = "java(splitLocationNames(entity.getLocationNames()))")
   Location toLocation(WeatherLocation entity);
 
   default List<String> splitLocationNames(String locationNames) {
     if (locationNames == null || locationNames.isBlank()) {
-      return List.of();
+      return Collections.emptyList();
     }
     return Arrays.stream(locationNames.split(","))
         .map(String::trim) // 공백 제거

--- a/src/main/java/com/team1/otvoo/weather/util/FcstItemUtils.java
+++ b/src/main/java/com/team1/otvoo/weather/util/FcstItemUtils.java
@@ -1,0 +1,35 @@
+package com.team1.otvoo.weather.util;
+
+
+import com.team1.otvoo.weather.dto.VilageFcstResponse.FcstItem;
+import java.util.List;
+
+public final class FcstItemUtils {
+
+  private FcstItemUtils() {}
+
+  // 그룹에서 해당 category의 FcstValue를 String으로 추출
+  public static String getValueByCategory(List<FcstItem> items, String category) {
+    return items.stream()
+        .filter(i -> category.equals(i.getCategory())) // 해당 category만 필터
+        .map(FcstItem::getFcstValue)
+        .findFirst()
+        .orElse(null);
+  }
+
+  // category 값을 Double로 변환 (null 또는 "-"는 null 반환)
+  public static Double parseDoubleByCategory(List<FcstItem> group, String category, ForecastParsingUtils parser) {
+    return parser.parseDouble(getValueByCategory(group, category));
+  }
+
+  // category 값을 강수/적설 전용 Double로 변환 (특정 문자열 → 0.0 처리)
+  public static Double parsePrecipOrSnowByCategory(List<FcstItem> group, String category, ForecastParsingUtils parser) {
+    return parser.parsePrecipitationOrSnow(getValueByCategory(group, category));
+  }
+
+  // category 값을 정수형 코드(Integer)로 변환 (null → 0)
+  public static Integer parseIntByCategory(List<FcstItem> group, String category, ForecastParsingUtils parser) {
+    Double val = parser.parseDouble(getValueByCategory(group, category));
+    return val != null ? val.intValue() : 0;
+  }
+}

--- a/src/main/java/com/team1/otvoo/weather/util/ForecastParsingUtils.java
+++ b/src/main/java/com/team1/otvoo/weather/util/ForecastParsingUtils.java
@@ -1,0 +1,43 @@
+package com.team1.otvoo.weather.util;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public final class ForecastParsingUtils {
+
+  /**
+   * 안전한 Double 파싱 - null 또는 "-" → null
+   */
+  public Double parseDouble(String value) {
+    if (value == null || "-".equals(value)) {
+      return null;
+    }
+    try {
+      return Double.valueOf(value.trim());
+    } catch (NumberFormatException e) {
+      return null;
+    }
+  }
+
+  /**
+   * 강수량 및 적설량 파싱 - null 또는 "-"/"강수없음"/"적설없음"/"0"→0.0
+   */
+  public Double parsePrecipitationOrSnow(String value) {
+    if (value == null || "-".equals(value)
+        || "강수없음".equals(value) || "적설없음".equals(value)
+        || "0".equals(value) || "0.0".equals(value)) {
+      return 0.0;
+    }
+    try {
+      return Double.valueOf(
+          value.replace("mm", "")
+              .replace("cm", "")
+              .replace("이상", "")
+              .split("~")[0]
+              .trim()
+      );
+    } catch (NumberFormatException e) {
+      return null;
+    }
+  }
+}

--- a/src/main/java/com/team1/otvoo/weather/util/GridCoordConverter.java
+++ b/src/main/java/com/team1/otvoo/weather/util/GridCoordConverter.java
@@ -1,0 +1,60 @@
+package com.team1.otvoo.weather.util;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.stereotype.Component;
+
+@Component
+public class GridCoordConverter {
+
+  // 고정된 기상청 설정값 (공식 수식 기반)
+  private static final double RE = 6371.00877;  // 지구 반경 (km)
+  private static final double GRID = 5.0;       // 격자 간격 (km)
+  private static final double SLAT1 = 30.0;     // 표준위도1
+  private static final double SLAT2 = 60.0;     // 표준위도2
+  private static final double OLON = 126.0;     // 기준점 경도
+  private static final double OLAT = 38.0;      // 기준점 위도
+  private static final double XO = 43;          // 기준점 X 좌표 (GRID 단위)
+  private static final double YO = 136;         // 기준점 Y 좌표 (GRID 단위)
+
+  public Point convert(double lat, double lng) {
+    double DEGRAD = Math.PI / 180.0;
+
+    double re = RE / GRID;
+    double slat1 = SLAT1 * DEGRAD;
+    double slat2 = SLAT2 * DEGRAD;
+    double olon = OLON * DEGRAD;
+    double olat = OLAT * DEGRAD;
+
+    double sn = Math.tan(Math.PI * 0.25 + slat2 * 0.5) / Math.tan(Math.PI * 0.25 + slat1 * 0.5);
+    sn = Math.log(Math.cos(slat1) / Math.cos(slat2)) / Math.log(sn);
+
+    double sf = Math.tan(Math.PI * 0.25 + slat1 * 0.5);
+    sf = Math.pow(sf, sn) * Math.cos(slat1) / sn;
+
+    double ro = Math.tan(Math.PI * 0.25 + olat * 0.5);
+    ro = re * sf / Math.pow(ro, sn);
+
+    double ra = Math.tan(Math.PI * 0.25 + (lat) * DEGRAD * 0.5);
+    ra = re * sf / Math.pow(ra, sn);
+
+    double theta = lng * DEGRAD - olon;
+    if (theta > Math.PI) theta -= 2.0 * Math.PI;
+    if (theta < -Math.PI) theta += 2.0 * Math.PI;
+    theta *= sn;
+
+    int x = (int) Math.floor(ra * Math.sin(theta) + XO + 0.5);
+    int y = (int) Math.floor(ro - ra * Math.cos(theta) + YO + 0.5);
+
+    return new Point(x, y);
+  }
+
+  @Getter
+  @AllArgsConstructor
+  @ToString
+  public static class Point {
+    private final int x;
+    private final int y;
+  }
+}

--- a/src/test/java/com/team1/otvoo/weather/batch/WeatherForecastProcessorTest.java
+++ b/src/test/java/com/team1/otvoo/weather/batch/WeatherForecastProcessorTest.java
@@ -1,0 +1,126 @@
+package com.team1.otvoo.weather.batch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import com.team1.otvoo.weather.dto.VilageFcstResponse.FcstItem;
+import com.team1.otvoo.weather.entity.PrecipitationType;
+import com.team1.otvoo.weather.entity.SkyStatus;
+import com.team1.otvoo.weather.entity.WeatherForecast;
+import com.team1.otvoo.weather.entity.WeatherHumidity;
+import com.team1.otvoo.weather.entity.WeatherLocation;
+import com.team1.otvoo.weather.entity.WeatherPrecipitation;
+import com.team1.otvoo.weather.entity.WeatherTemperature;
+import com.team1.otvoo.weather.entity.WeatherWindSpeed;
+import com.team1.otvoo.weather.entity.WindStrength;
+import com.team1.otvoo.weather.util.ForecastParsingUtils;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class WeatherForecastProcessorTest {
+
+  @Mock
+  private ForecastParsingUtils parsingUtils;
+
+  @InjectMocks
+  private WeatherForecastProcessor processor;
+
+  @BeforeEach
+  void setUp() {
+    // JobParameters처럼 필드에 주입
+    ReflectionTestUtils.setField(processor, "latitude", 37.5);
+    ReflectionTestUtils.setField(processor, "longitude", 126.8);
+    ReflectionTestUtils.setField(processor, "x", 60);
+    ReflectionTestUtils.setField(processor, "y", 127);
+    ReflectionTestUtils.setField(processor, "locationNames", "서울특별시,강남구,대치동");
+  }
+
+  @Test
+  void process_validItems_returnsOneForecast() throws Exception {
+    // given: 샘플 FcstItem 리스트 (한 시점)
+    List<FcstItem> items = new ArrayList<>();
+    items.add(new FcstItem("20250729", "0200", "20250729", "0200", "TMP", "21", 60, 127));
+    items.add(new FcstItem("20250729", "0200", "20250729", "0200", "TMN", "18", 60, 127));
+    items.add(new FcstItem("20250729", "0200", "20250729", "0200", "TMX", "25", 60, 127));
+    items.add(new FcstItem("20250729", "0200", "20250729", "0200", "REH", "60", 60, 127));
+    items.add(new FcstItem("20250729", "0200", "20250729", "0200", "WSD", "5", 60, 127));
+    items.add(new FcstItem("20250729", "0200", "20250729", "0200", "POP", "30", 60, 127));
+    items.add(new FcstItem("20250729", "0200", "20250729", "0200", "PTY", "1", 60, 127));
+    items.add(new FcstItem("20250729", "0200", "20250729", "0200", "PCP", "2", 60, 127));
+    items.add(new FcstItem("20250729", "0200", "20250729", "0200", "SKY", "1", 60, 127));
+
+    // parsingUtils.parseDouble(...)와 parsePrecipitationOrSnow(...) 동작 모킹
+    when(parsingUtils.parseDouble(anyString()))
+        .thenAnswer(inv -> {
+          String v = inv.getArgument(0);
+          return v == null ? null : Double.valueOf(v);
+        });
+    when(parsingUtils.parsePrecipitationOrSnow(anyString()))
+        .thenAnswer(inv -> {
+          String v = inv.getArgument(0);
+          return v == null ? 0.0 : Double.valueOf(v);
+        });
+
+    // when
+    List<WeatherForecast> results = processor.process(items);
+
+    // then
+    assertThat(results).hasSize(1);
+    WeatherForecast forecast = results.get(0);
+
+    // 예상 Instant (KST 2025-07-29 02:00 → UTC 2025-07-28T17:00:00Z)
+    Instant expectedInstant = ZonedDateTime.of(
+        2025, 7, 29, 2, 0, 0, 0,
+        ZoneId.of("Asia/Seoul")
+    ).toInstant();
+
+    // 예보 발표 시각 검증
+    assertThat(forecast.getForecastedAt()).isEqualTo(expectedInstant);
+    // 예보 적용 시각 검증
+    assertThat(forecast.getForecastAt()).isEqualTo(expectedInstant);
+
+    // 온도 검증
+    WeatherTemperature temp = forecast.getTemperature();
+    assertThat(temp.getCurrent()).isEqualTo(21.0);
+    assertThat(temp.getMin()).isEqualTo(18.0);
+    assertThat(temp.getMax()).isEqualTo(25.0);
+
+    // 습도 검증
+    WeatherHumidity hum = forecast.getHumidity();
+    assertThat(hum.getCurrent()).isEqualTo(60.0);
+
+    // 풍속 검증
+    WeatherWindSpeed wind = forecast.getWindSpeed();
+    assertThat(wind.getSpeed()).isEqualTo(5.0);
+    assertThat(wind.getAsWord()).isEqualTo(WindStrength.MODERATE);
+
+    // 강수 검증
+    WeatherPrecipitation precip = forecast.getPrecipitation();
+    assertThat(precip.getProbability()).isEqualTo(30.0);
+    assertThat(precip.getAmount()).isEqualTo(2.0);
+    assertThat(precip.getType()).isEqualTo(PrecipitationType.RAIN);
+
+    // 하늘 상태 검증
+    assertThat(forecast.getSkyStatus()).isEqualTo(SkyStatus.CLEAR);
+
+    // 위치 검증
+    WeatherLocation loc = forecast.getLocation();
+    assertThat(loc.getLatitude()).isEqualTo(37.5);
+    assertThat(loc.getLongitude()).isEqualTo(126.8);
+    assertThat(loc.getX()).isEqualTo(60);
+    assertThat(loc.getY()).isEqualTo(127);
+    assertThat(loc.getLocationNames()).isEqualTo("서울특별시,강남구,대치동");
+  }
+}


### PR DESCRIPTION
## #️⃣ Issue Number
KAN-63

## 📝 요약(Summary)
- **JobParameters 주입**
    - `latitude`, `longitude`, `x`, `y`, `locationNames` 값 주입 (`@StepScope` + `@Value`)
- **데이터 그룹핑 및 파싱**
    - `FcstItem`을 `(fcstDate, fcstTime)` 기준으로 그룹핑
    - 카테고리별 데이터 추출 및 변환
        - TMP, TMN, TMX → `WeatherTemperature`
        - REH → `WeatherHumidity`
        - WSD → `WeatherWindSpeed`
        - POP, PTY, PCP → `WeatherPrecipitation`
        - SKY → `SkyStatus`
- **시간 계산 및 엔티티 생성**
    - 예보 발표 시간(`forecastedAt`)과 예보 적용 시간(`forecastAt`) 계산
    - `WeatherForecast` 및 `WeatherLocation` 생성
    - 하위 엔티티(Temperature, Humidity, Precipitation, WindSpeed) 연동
- **리스트 반환 및 테스트 완료**
    - 모든 그룹 처리 후 `List<WeatherForecast>` 반환
    - `WeatherForecastProcessorTest`를 통해 시각, 값, 엔티티 매핑 검증 완료

추가로 아래 사항은 배치 작업 관련한 흐름입니다. 
날씨 데이터 관리 기능에서 Batch는 3단계로 동작합니다. 

> 1. **Reader**
>     - 좌표 목록을 준비한 뒤 위도·경도를 이용하여 1)`GridCoordConverter`로 x, y로 변환, 2) Kakao Local API를 통해 행정구역명 추출
> 이 좌표·행정구역 정보를 `JobParameters`에 세팅한 후, 해당 x, y로 기상청 단기예보 API를 호출해 응답을 `FcstItem` 리스트로 변환
> 2. **Processor**
>     - 위에 요약 참고(데이터 가공 및 변환)
> 3. **Writer**
>     - 생성된 엔티티를 DB에 저장

현재 Processor 구현만 완료 했으며,  Reader와 Writer는 다음 PR로 구현 후 올릴 예정입니다.  +  온도 및 습도 관련한 `comparedToDayBefore` 계산 로직은 추후 추가할 예정입니다.


## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트). 

