### PR TITLE
[팔로우] fix: KAN-341 팔로잉 목록 조회, 팔로워 목록 조회 수정

### DIFF
--- a/src/main/java/com/team1/otvoo/follow/controller/FollowController.java
+++ b/src/main/java/com/team1/otvoo/follow/controller/FollowController.java
@@ -72,7 +72,7 @@ public class FollowController {
 
   @GetMapping("/followers")
   public ResponseEntity<FollowListResponse> getFollowerList(
-      @RequestParam("followerId") UUID followeeId,
+      @RequestParam("followeeId") UUID followeeId,
       @RequestParam(value = "cursor", required = false) String cursor,
       @RequestParam(value = "idAfter", required = false) UUID idAfter,
       @RequestParam(value = "limit", defaultValue = "20") int limit,

--- a/src/main/java/com/team1/otvoo/follow/dto/FollowCursorDto.java
+++ b/src/main/java/com/team1/otvoo/follow/dto/FollowCursorDto.java
@@ -1,0 +1,14 @@
+package com.team1.otvoo.follow.dto;
+
+import com.team1.otvoo.user.dto.UserSummary;
+import java.time.Instant;
+import java.util.UUID;
+
+public record FollowCursorDto(
+    UUID id,
+    Instant createdAt,
+    UserSummary followee,
+    UserSummary follower
+) {
+
+}

--- a/src/main/java/com/team1/otvoo/follow/repository/FollowRepositoryCustom.java
+++ b/src/main/java/com/team1/otvoo/follow/repository/FollowRepositoryCustom.java
@@ -1,11 +1,11 @@
 package com.team1.otvoo.follow.repository;
 
-import com.team1.otvoo.follow.entity.Follow;
+import com.team1.otvoo.follow.dto.FollowCursorDto;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
 public interface FollowRepositoryCustom {
-  List<Follow> findFollowingsWithCursor(UUID followerId, Instant cursor, UUID idAfter, int limit, String nameLike);
-  List<Follow> findFollowersWithCursor(UUID followeeId, Instant cursor, UUID idAfter, int limit, String nameLike);
+  List<FollowCursorDto> findFollowingsWithCursor(UUID followerId, Instant cursor, UUID idAfter, int limit, String nameLike);
+  List<FollowCursorDto> findFollowersWithCursor(UUID followeeId, Instant cursor, UUID idAfter, int limit, String nameLike);
 }

--- a/src/main/java/com/team1/otvoo/follow/repository/FollowRepositoryCustomImpl.java
+++ b/src/main/java/com/team1/otvoo/follow/repository/FollowRepositoryCustomImpl.java
@@ -1,10 +1,13 @@
 package com.team1.otvoo.follow.repository;
 
+import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import com.team1.otvoo.follow.entity.Follow;
+import com.team1.otvoo.follow.dto.FollowCursorDto;
 import com.team1.otvoo.follow.entity.QFollow;
+import com.team1.otvoo.user.dto.UserSummary;
 import com.team1.otvoo.user.entity.QProfile;
+import com.team1.otvoo.user.entity.QProfileImage;
 import com.team1.otvoo.user.entity.QUser;
 import java.time.Instant;
 import java.util.List;
@@ -25,43 +28,70 @@ public class FollowRepositoryCustomImpl implements FollowRepositoryCustom {
   }
 
   @Override
-  public List<Follow> findFollowingsWithCursor(UUID followerId, Instant cursor, UUID idAfter, int limit,
+  public List<FollowCursorDto> findFollowingsWithCursor(UUID followerId, Instant cursor, UUID idAfter, int limit,
       String nameLike) {
     return findFollowListWithCursor(followerId, cursor, idAfter, limit, nameLike, SearchType.FOLLOWING);
   }
 
   @Override
-  public List<Follow> findFollowersWithCursor(UUID followeeId, Instant cursor, UUID idAfter, int limit,
+  public List<FollowCursorDto> findFollowersWithCursor(UUID followeeId, Instant cursor, UUID idAfter, int limit,
       String nameLike) {
     return findFollowListWithCursor(followeeId, cursor, idAfter, limit, nameLike, SearchType.FOLLOWER);
   }
 
-  private List<Follow> findFollowListWithCursor(UUID userId, Instant cursor, UUID idAfter, int limit,
+  private List<FollowCursorDto> findFollowListWithCursor(UUID userId, Instant cursor, UUID idAfter, int limit,
       String nameLike, SearchType type){
 
     QFollow follow = QFollow.follow;
-    QUser userToJoin;
-    QProfile profile = QProfile.profile;
-    BooleanExpression userIdCondition;
+    QUser userFollowee = new QUser("userFollowee");
+    QUser userFollower = new QUser("userFollower");
 
+    QProfile profileFollowee = new QProfile("profileFollowee");
+    QProfile profileFollower = new QProfile("profileFollower");
+
+    QProfileImage imageFollowee = new QProfileImage("imageFollowee");
+    QProfileImage imageFollower = new QProfileImage("imageFollower");
+
+    BooleanExpression userIdCondition;
     if (type == SearchType.FOLLOWING) {
       // followee 목록 조회
-      userToJoin = follow.followee;
       userIdCondition = follow.follower.id.eq(userId);
     } else {
       // follower 목록 조회
-      userToJoin = follow.follower;
       userIdCondition = follow.followee.id.eq(userId);
     }
 
     return queryFactory
-        .selectFrom(follow)
-        .join(userToJoin).fetchJoin()
-        .leftJoin(profile).on(profile.user.id.eq(userToJoin.id)).fetchJoin()
+        .select(Projections.constructor(FollowCursorDto.class,
+            follow.id,
+            follow.createdAt,
+            Projections.constructor(UserSummary.class,
+                userFollowee.id,
+                profileFollowee.name,
+                imageFollowee.imageUrl
+            ),
+            Projections.constructor(UserSummary.class,
+                userFollower.id,
+                profileFollower.name,
+                imageFollower.imageUrl
+            )
+        ))
+        .from(follow)
+        .join(userFollowee).on(userFollowee.id.eq(follow.followee.id))
+        .join(userFollower).on(userFollower.id.eq(follow.follower.id))
+
+        // followee 쪽 profile + image
+        .leftJoin(profileFollowee).on(profileFollowee.user.id.eq(userFollowee.id))
+        .leftJoin(imageFollowee).on(imageFollowee.profile.id.eq(profileFollowee.id))
+
+        // follower 쪽 profile + image
+        .leftJoin(profileFollower).on(profileFollower.user.id.eq(userFollower.id))
+        .leftJoin(imageFollower).on(imageFollower.profile.id.eq(profileFollower.id))
+
         .where(
-            userIdCondition, // ID 조건
-            nameLike(profile, nameLike), // 사용자 이름 검색 조건
-            cursorCondition(follow, cursor, idAfter) // 커서 조건
+            userIdCondition,
+            nameLikeCondition(type, profileFollowee, profileFollower, nameLike),
+            cursorCondition(follow, cursor, idAfter)
         )
         .orderBy(follow.createdAt.desc(), follow.id.desc())
         .limit(limit)
@@ -69,11 +99,15 @@ public class FollowRepositoryCustomImpl implements FollowRepositoryCustom {
   }
 
   // 사용자 이름 검색 조건
-  private BooleanExpression nameLike(QProfile profile, String nameLike) {
+  private BooleanExpression nameLikeCondition(SearchType type, QProfile profileFollowee, QProfile profileFollower, String nameLike) {
     if (!StringUtils.hasText(nameLike)) {
       return null;
     }
-    return profile.name.containsIgnoreCase(nameLike);
+    if (type == SearchType.FOLLOWING) {
+      return profileFollowee.name.containsIgnoreCase(nameLike);
+    } else {
+      return profileFollower.name.containsIgnoreCase(nameLike);
+    }
   }
 
   // 커서 조건


### PR DESCRIPTION
## #️⃣ Issue Number
KAN-341

## 📝 요약(Summary)
- 팔로잉 목록 조회, 팔로워 목록 조회 수정
  - mapper 사용하는 대신 QueryDSL Projection 사용하는 방식으로 수정 

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트). 

